### PR TITLE
Implemented option to retain obsolete terms if they have an alt_id listed.

### DIFF
--- a/hpo_similarity/__main__.py
+++ b/hpo_similarity/__main__.py
@@ -65,6 +65,9 @@ def get_options():
     parser.add_argument("--iterations", type=int, default=100000,
         help="whether to permute the probands across genes, in order to assess \
             method robustness.")
+    parser.add_argument("--use-alt-id-if-hpo-term-obsolete", default=False, action="store_true",
+        help="map HPO terms to the standard id even if the term is labeled obsolete.")
+
     
     # allow for using different similarity scoring metrics
     group = parser.add_mutually_exclusive_group()
@@ -99,7 +102,7 @@ def main():
     # load HPO terms and probands for each gene
     print("loading HPO terms and probands by gene")
     hpo_by_proband = load_participants_hpo_terms(options.phenotypes_path, \
-        alt_ids, obsolete)
+        alt_ids, obsolete, options.use_alt_id_hpo_term_obsolete)
     probands_by_gene = load_genes(options.genes_path)
     
     if options.permute:

--- a/hpo_similarity/load_files.py
+++ b/hpo_similarity/load_files.py
@@ -21,13 +21,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import json
 
-def load_participants_hpo_terms(path, alt_ids, obsolete):
+def load_participants_hpo_terms(path, alt_ids, obsolete, use_alt_id_if_hpo_term_obsolete=False):
     """ loads patient HPO terms
     
     Args:
         path: path to JSON-encoded patient phenotype file.
         alt_ids: dict to map HPO terms from their alt_id, to their current ID
         obsolete: set of obsolete HPO IDs
+        use_alt_id_if_hpo_term_obsolete: retain terms that are obsolete if they're also in alt_ids
     
     Returns:
         dictionary of HPO term lists indexed by proband ID e.g. {DDD01:
@@ -44,6 +45,8 @@ def load_participants_hpo_terms(path, alt_ids, obsolete):
         # strip out the obsolete terms, currently there are two probands (out of
         # >4000) who each have an obsolete term, so it's not worth converting the
         # obsolete terms to a more appropriate term
+        if use_alt_id_if_hpo_term_obsolete:
+            obsolete -= set(alt_ids.keys())
         terms = [term for term in terms if term not in obsolete]
         
         # convert each term to it's standard HPO ID if the term is in the HPO IDs,


### PR DESCRIPTION
Thanks for the code you've made available here.  I'm adapting your method for another use case and observed that for several of my probands I ended up having no HPO terms retained because they were labeled obsolete but also showed up in alt_ids.  So, simply, this change allows the user to retain obsolete terms if there is an alt_id given for the term (while leaving the default behavior alone).